### PR TITLE
fix :too many createing clients

### DIFF
--- a/packages/ioredis-conn-pool/lib/Factory.js
+++ b/packages/ioredis-conn-pool/lib/Factory.js
@@ -11,14 +11,20 @@ class Factory {
   create() {
     const { redis: redisOptions, context, logger } = this;
     return new Promise(function createRedis(resolve, reject) {
-      const ioredis = new Redis(redisOptions);
+      let ioredis = new Redis(redisOptions);
+      let isConnectedOnStart = false;
       ioredis
         .on('error', function (e) {
+          if (!isConnectedOnStart) {
+            ioredis.quit();
+            ioredis = null;
+          }
           logger.error(e);
           context.emit('error', e, ioredis);
           reject(e);
         })
         .on('connect', function () {
+          isConnectedOnStart = true;
           context.emit('connect', ioredis);
         })
         .on('ready', function () {


### PR DESCRIPTION
If redis is not available, then Factory.create will be rejected, and generic-pool try to re-create the client. As a result, too many clients are created in heap. When redis becomes available, these clients can take all the free connections.

Steps for reproduce:
1. stop redis server
2. create pool
3. subscribe on event 'error'
4. call getConnection()

Sample code:
```js
const poolOptions = {
    host: "127.0.0.1",
    port: "6379",
};
const redisPool = new RedisPool(poolOptions);

redisPool.on('error', (e, client) => {
  console.log(`error: ${e.message}`);
});

const client = redisPool.getConnection()
    .then(() => console.log('client create'))
    .catch(e => console.error(`client error: ${e.message}`));
```